### PR TITLE
ci: add validate + pytest + secret-scan workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  validate:
+    uses: Molecule-AI/molecule-ci/.github/workflows/validate-workspace-template.yml@main
+
+  pytest:
+    name: Python unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install runtime deps
+        run: |
+          pip install --upgrade pip
+          pip install -q -r requirements.txt
+          pip install -q pytest pytest-asyncio pytest-cov
+      - name: Run pytest
+        run: pytest tests/ -v --cov=. --cov-report=term

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,6 @@
+name: Secret scan
+on: [push, pull_request]
+jobs:
+  secret-scan:
+    name: Scan diff for credential-shaped strings
+    uses: Molecule-AI/molecule-ci/.github/workflows/secret-scan.yml@main


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` and `.github/workflows/secret-scan.yml`, bringing this template in line with the hermes + openclaw templates.
- Pytest job runs the full test suite (51 tests, 100% coverage on adapter/app_server/executor) on every push/PR.
- The reusable `validate-workspace-template.yml` from `Molecule-AI/molecule-ci` ships the static template-shape validation.
- Secret-scan blocks credential-shaped strings on diff.

Without this PR the codex template had **zero** CI — the 51 unit tests landed in #1 only ran locally.

## Test plan

- [ ] Workflow runs on this PR — validate the three jobs succeed.
- [ ] Coverage report shows ≥97% on prod modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)