### PR TITLE
ci: add publish-image.yml — bake codex binary into workspace image

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,37 @@
+name: publish-image
+
+# Builds this workspace template's Dockerfile and pushes it to GHCR as
+# `ghcr.io/molecule-ai/workspace-template-<runtime>:latest` + `:sha-<7>`.
+# The heavy lifting lives in the reusable workflow in molecule-ci —
+# change it there if the publish pattern needs to evolve.
+
+on:
+  # Re-publish when a new molecule-ai-workspace-runtime is released to
+  # PyPI. Sent by molecule-core's publish-runtime.yml `cascade` job via
+  # repository_dispatch with event-type "runtime-published".
+  # client_payload.runtime_version carries the new version string.
+  repository_dispatch:
+    types: [runtime-published]
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      runtime_version:
+        description: "Optional explicit runtime version to bake in (forwarded as RUNTIME_VERSION build-arg)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    uses: Molecule-AI/molecule-ci/.github/workflows/publish-template-image.yml@main
+    secrets: inherit
+    with:
+      # Cascade fires with client_payload.runtime_version = the exact
+      # version PyPI just published. Forwarded as a docker --build-arg
+      # so the cache key changes per-version and pip install resolves
+      # freshly. Empty on push/PR — falls back to requirements.txt pin.
+      runtime_version: ${{ github.event.client_payload.runtime_version || inputs.runtime_version || '' }}


### PR DESCRIPTION
## Summary

Closes #3 — workspace boot fails on staging because the codex binary isn't in the runtime container.

This template ships a Dockerfile that installs `@openai/codex` via npm, but had no GitHub Actions workflow to publish the built image to GHCR. Sibling templates (hermes, openclaw) have `publish-image.yml`; this one didn't, so the platform's tenant runtime was falling back to cloning the adapter into a generic image without the codex binary.

Pattern is identical to hermes/openclaw — reuses `Molecule-AI/molecule-ci/.github/workflows/publish-template-image.yml`.

## Test plan

- [ ] Workflow runs on merge to main.
- [ ] `ghcr.io/molecule-ai/workspace-template-codex:latest` is published.
- [ ] Re-provision a codex workspace on staging — boot reaches `online`, codex binary present on PATH inside container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)