### PR TITLE
fix(Dockerfile): drop obsolete preflight monkey-patch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt && \
     if [ -n "${RUNTIME_VERSION}" ]; then \
       pip install --no-cache-dir --upgrade "molecule-ai-workspace-runtime==${RUNTIME_VERSION}"; \
-    fi && \
-    python3 -c "import molecule_runtime.preflight as pf; pf.SUPPORTED_RUNTIMES.add('codex')" && \
-    SITE=$(python3 -c 'import molecule_runtime.preflight as p; print(p.__file__)') && \
-    sed -i "s/SUPPORTED_RUNTIMES = {/SUPPORTED_RUNTIMES = {'codex',/" "$SITE"
+    fi
 
 COPY adapter.py executor.py app_server.py __init__.py ./
 COPY start.sh /usr/local/bin/start.sh


### PR DESCRIPTION
## Summary

- Removes the obsolete `pf.SUPPORTED_RUNTIMES.add('codex')` + `sed -i` monkey-patch that was failing the publish-image build at step 7/13.
- Runtime ≥0.1.x replaced the static allowlist with adapter-discovery via `ADAPTER_MODULE` (see `_validate_runtime_via_adapter` in `molecule_runtime/preflight.py`), so the patch is dead code.
- `ADAPTER_MODULE=adapter` is already set later in the Dockerfile, which is the path the new discovery uses to validate this runtime.

## Test plan

- [x] First publish-image build (post-#4 merge) failed with `AttributeError: module 'molecule_runtime.preflight' has no attribute 'SUPPORTED_RUNTIMES'`
- [ ] After this PR merges, publish-image build succeeds and pushes `:latest` + `:sha-...`
- [ ] Boot smoke (in publish-image workflow) confirms `from adapter import Adapter` works against installed runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)