### PR TITLE
fix(codex): handle codex 0.72 snake_case event schema

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -206,26 +206,49 @@ class CodexAppServerExecutor(AgentExecutor):
         loop = asyncio.get_running_loop()
 
         def on_notification(method: str, params: dict[str, Any]) -> None:
-            # Codex v2 protocol notifications. Only the message stream
-            # + completion + error map onto our flow today; everything
-            # else (reasoning, tool exec, token usage) is logged for
-            # observability but not surfaced to the A2A response.
+            # Codex app-server notifications. The schema is `experimental`
+            # and has shifted across releases — current codex 0.72 emits
+            # snake_case event names (`agent_message`, `task_complete`,
+            # `turn_aborted`); earlier codex 2.x emitted slash/dot forms
+            # (`turn/completed`). We accept both shapes so a codex bump
+            # doesn't strand the workspace silently with empty replies
+            # (caught live during the 2026-05-03 4-runtime A2A E2E:
+            # codex 0.72 returned empty text because executor only knew
+            # the old `turn/completed` + `agent_message_delta` names).
+            #
+            # Surfaced events:
+            #   - text deltas: `agent_message_delta` (chunk) and
+            #     `agent_message` (whole — fired when the model chose
+            #     not to stream chunks; we treat it as a final delta)
+            #   - completion: `task_complete` (0.72) /
+            #     `turn/completed` (older schemas)
+            #   - error/abort: `error_notification`, `turn_aborted`,
+            #     `stream_error`
+            # Other notifications (reasoning, tool exec, token usage)
+            # are debug-logged for observability but not surfaced.
             if method == "agent_message_delta":
                 delta = params.get("delta") or params.get("text") or ""
                 if delta:
                     state.deltas.append(delta)
-            elif method in ("turn/completed", "turn.completed"):
-                # Match either dotted or slashed form — schema is in
-                # flux during the experimental phase. Also tolerate
-                # both `turnId` (schema) and `id` (real binary) for
-                # the params id field.
-                tid = params.get("turnId") or params.get("id")
+            elif method == "agent_message":
+                # Whole-message form: codex emits this when the model
+                # response wasn't streamed as chunks. The full text
+                # lives under `message` (0.72) or `text`. Append it
+                # as a single delta so the assembled string is
+                # complete even when no `_delta` notifications fire.
+                msg = params.get("message") or params.get("text") or ""
+                if msg:
+                    state.deltas.append(msg)
+            elif method in ("turn/completed", "turn.completed", "task_complete"):
+                # Tolerate dotted / slashed / snake_case schema variants
+                # (codex changes these across minors). Also accept both
+                # `turnId` and `id` for the params id field.
+                tid = params.get("turnId") or params.get("id") or params.get("task_id")
                 if tid in (None, state.turn_id):
                     loop.call_soon_threadsafe(state.completed.set)
-            elif method == "error_notification":
-                state.error = RuntimeError(
-                    params.get("message", "unknown app-server error")
-                )
+            elif method in ("error_notification", "stream_error", "turn_aborted"):
+                msg = params.get("message") or params.get("error") or method
+                state.error = RuntimeError(str(msg))
                 loop.call_soon_threadsafe(state.completed.set)
             else:
                 logger.debug("codex notification: %s %s", method, params)

--- a/tests/test_executor_paths.py
+++ b/tests/test_executor_paths.py
@@ -240,6 +240,52 @@ async def test_completed_dotted_form_also_completes_turn():
 
 
 @pytest.mark.asyncio
+async def test_codex072_snake_case_event_schema():
+    """codex 0.72 emits snake_case event names: `agent_message`
+    (whole reply, no streaming) + `task_complete` (instead of
+    `turn/completed`). Both must produce a populated text result —
+    pre-fix codex returned empty text because the executor only
+    knew the older slash/dot schema. Caught live during 2026-05-03
+    4-runtime A2A E2E."""
+    fake = FakeAppServer()
+    ex = _make(fake)
+
+    async def driver():
+        for _ in range(50):
+            if any(m == "turn/start" for m, _ in fake.requests):
+                break
+            await asyncio.sleep(0.01)
+        # Whole-message form (codex 0.72 when model didn't stream chunks)
+        fake.push("agent_message", {"message": "snake_case ok"})
+        fake.push("task_complete", {"task_id": "tu_1"})
+
+    driver_task = asyncio.create_task(driver())
+    text = await ex._run_turn("snake-case")
+    await driver_task
+    assert text == "snake_case ok"
+
+
+@pytest.mark.asyncio
+async def test_codex072_turn_aborted_surfaces_as_error():
+    """`turn_aborted` (codex 0.72) and `stream_error` map to the
+    same error path as the older `error_notification`."""
+    fake = FakeAppServer()
+    ex = _make(fake)
+
+    async def driver():
+        for _ in range(50):
+            if any(m == "turn/start" for m, _ in fake.requests):
+                break
+            await asyncio.sleep(0.01)
+        fake.push("turn_aborted", {"message": "user pressed Ctrl-C"})
+
+    driver_task = asyncio.create_task(driver())
+    with pytest.raises(RuntimeError, match="user pressed Ctrl-C"):
+        await ex._run_turn("aborted")
+    await driver_task
+
+
+@pytest.mark.asyncio
 async def test_unknown_notification_methods_are_logged_and_ignored(caplog):
     fake = FakeAppServer()
     ex = _make(fake)


### PR DESCRIPTION
## Summary
- Executor now accepts codex 0.72's snake_case events (\`agent_message\`, \`task_complete\`, \`turn_aborted\`, \`stream_error\`) in addition to the older slash/dot schema (\`agent_message_delta\`, \`turn/completed\`, \`error_notification\`).
- Two new tests pin the 0.72 branches.

## Why
The 2026-05-03 4-runtime A2A E2E surfaced this on the codex workspace: every probe returned an empty text body. Root cause:
- codex 0.72 fires \`agent_message\` (whole reply) when the model doesn't stream chunks; the executor only knew \`agent_message_delta\` (chunk).
- codex 0.72 fires \`task_complete\`; the executor only knew \`turn/completed\`.
- Result: deltas list stays empty + completion never matches a known method → turn resolves with empty assembled string + no error surfaced.

The codex app-server protocol is documented as \`experimental\`, so accepting the union of known schemas is the right shape — every codex bump can shift names. Pinned tolerance beats blind acceptance.

## Test plan
- [x] \`pytest tests/\` (59 passed, +2)
- [ ] After merge: rerun codex A2A probe in v6 tenant, confirm reply contains the model's actual text instead of an empty string