### PR TITLE
fix(codex): wrap RuntimeError from notification path in [codex error]

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -161,6 +161,20 @@ class CodexAppServerExecutor(AgentExecutor):
                     new_text_message(f"[codex unreachable] {exc!s}")
                 )
                 return
+            except RuntimeError as exc:
+                # Surfaced from `state.error` in `_run_turn` — codex emitted
+                # an `error` notification (typically an upstream HTTP failure
+                # from the model provider, e.g. `unexpected status 401
+                # Unauthorized`). Wrapping with the same `[codex error]`
+                # prefix the AppServerError path uses keeps the canvas-side
+                # behavior consistent: a clear inline message instead of a
+                # bare JSON-RPC -32603 leak from the a2a-sdk top-level
+                # handler.
+                logger.warning("codex turn surfaced error: %s", exc)
+                await event_queue.enqueue_event(
+                    new_text_message(f"[codex error] {exc}")
+                )
+                return
 
         await event_queue.enqueue_event(new_text_message(text))
 

--- a/tests/test_executor_paths.py
+++ b/tests/test_executor_paths.py
@@ -126,6 +126,37 @@ async def test_execute_handles_turn_timeout(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_execute_wraps_runtimeerror_from_notification_path():
+    """When codex emits an `error` notification mid-turn, `_run_turn`
+    raises a RuntimeError. execute() should wrap it with the same
+    `[codex error]` prefix the AppServerError path uses — without
+    this wrap, a2a-sdk's top-level handler returns a bare JSON-RPC
+    -32603, which surfaces in the canvas as a confusing protocol
+    error rather than the actual upstream message.
+
+    Captured live on staging 2026-05-03 against codex 0.72: a fake
+    OPENAI_API_KEY produced `unexpected status 401 Unauthorized` from
+    the codex HTTP client; pre-fix the canvas saw the raw JSON-RPC
+    wrapper with the message buried in `error.message`."""
+    fake = FakeAppServer()
+    ex = _make(fake)
+    queue = _CapturingQueue()
+
+    async def driver():
+        for _ in range(50):
+            if any(m == "turn/start" for m, _ in fake.requests):
+                break
+            await asyncio.sleep(0.01)
+        fake.push_event("error", message="unexpected status 401 Unauthorized")
+
+    await asyncio.gather(ex.execute(_ctx("test 401"), queue), driver())
+    assert len(queue.events) == 1
+    text = repr(queue.events[0])
+    assert "codex error" in text
+    assert "401" in text
+
+
+@pytest.mark.asyncio
 async def test_execute_handles_connection_error_and_resets():
     """ConnectionError mid-turn should drop cached state so the next
     turn re-bootstraps."""


### PR DESCRIPTION
## Summary
- Caught live on staging today: a codex workspace with a bad `OPENAI_API_KEY` returned a bare JSON-RPC -32603 to the canvas instead of the operator-friendly `[codex error] ...` shape used elsewhere.
- Root cause: `_run_turn` raises a plain `RuntimeError` when the codex `error` notification fires (typical for upstream provider HTTP failures). `execute()` only caught `AppServerError`, so RuntimeError bubbled up to a2a-sdk's top-level handler.
- Fix: catch `RuntimeError` in `execute()` and surface with the same `[codex error]` prefix.

The schema fix from #8 was working — events were being parsed. This is the UX layer that turns the parsed error into a readable message.

## Test plan
- [x] Added `test_execute_wraps_runtimeerror_from_notification_path` — drives an `error` notification post-turn-start, asserts `[codex error]` + `401` in the assistant text.
- [x] `pytest tests/test_executor.py tests/test_executor_paths.py -v` → 25/25 pass.
- [ ] Re-probe staging codex workspace; expect `[codex error] unexpected status 401 ...` in canvas instead of JSON-RPC -32603.

🤖 Generated with [Claude Code](https://claude.com/claude-code)