### PR TITLE
fix(codex): drop bogus gosu -E flag

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -46,4 +46,4 @@ fi
 
 # Hand off to molecule-runtime. From here, every A2A message routes
 # through executor.py → app_server.py → codex app-server child.
-exec gosu -E agent molecule-runtime
+exec gosu agent molecule-runtime


### PR DESCRIPTION
## Summary
PR #10's start.sh ended in `exec gosu -E agent molecule-runtime`. `-E` is a sudo flag, not a gosu flag — gosu always passes env through. Boot smoke failed with `unable to find user -E`, blocking the publish-image gate.

Same fix as pre-PR-#10 form. The bridge's exported OPENAI_API_KEY still propagates because gosu inherits parent env by default.

## Test plan
- [x] `git diff` is exactly one character delta.
- [ ] CI boot smoke passes.
- [ ] publish-image succeeds.
- [ ] Recreate codex workspace with `MINIMAX_API_KEY` and verify A2A returns assistant text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)