### PR TITLE
fix(codex): invoke codex_minimax_config.sh from bare-host install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,3 +66,17 @@ if ! command -v codex >/dev/null 2>&1; then
   exit 1
 fi
 echo "[install.sh] codex ready: $(command -v codex) ($(codex --version 2>/dev/null || echo version-unknown))"
+
+# --- Bare-host MiniMax provider config -----------------------------
+# In the SaaS bare-host boot path, install.sh runs once and then CP's
+# user-data exec's molecule-runtime — there's no equivalent of Docker's
+# start.sh that we can hook codex_minimax_config.sh into. Invoke it
+# here so the [model_providers.minimax] block lands in ~/.codex/config.toml
+# before codex first runs. Bridge script no-ops when MINIMAX_API_KEY is
+# missing, so OpenAI-direct deploys see no behavior change.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -f "$SCRIPT_DIR/codex_minimax_config.sh" ]; then
+  echo "[install.sh] running codex_minimax_config.sh (provider config write)"
+  bash "$SCRIPT_DIR/codex_minimax_config.sh" || \
+    echo "[install.sh] WARN: codex_minimax_config.sh exited non-zero — workspace may run on default provider" >&2
+fi


### PR DESCRIPTION
## Summary
PR #12 wired the MiniMax config writer into the **Docker** boot path (`start.sh` sources `codex_minimax_config.sh`) but missed the **SaaS bare-host** path. On bare-host, CP's user-data runs `install.sh` once and then `exec`'s molecule-runtime — there's no `start.sh` hook. So `~/.codex/config.toml` never got written, codex fell back to its default provider, and tried to authenticate against MiniMax with the wrong header → `401 Unauthorized`.

## Caught live
Staging today: workspace boot succeeded, A2A reply was `[codex error] exceeded retry limit, last status: 401 Unauthorized, request id: 9f5d36e8...-CMH` (CMH = MiniMax's CDN edge — confirms codex did reach MiniMax, just couldn't auth).

`MINIMAX_API_KEY` was correctly injected from the tenant's global secrets, and `codex_minimax_config.sh`'s own tests pass — the gap was purely in the boot wiring.

## Fix
Invoke `codex_minimax_config.sh` at the end of `install.sh`, after the codex CLI is installed. Script already no-ops without the key, so OpenAI-direct deploys are unaffected. `SCRIPT_DIR` uses `BASH_SOURCE` so we work whether install.sh sits at `/opt/adapter` (CP user-data) or `/app` (Docker fallback).

## Test plan
- [x] `tests/test_codex_minimax_config.sh` — 13 assertions (already covers the script's behavior independent of boot path).
- [ ] Recreate codex workspace on staging with `MINIMAX_API_KEY`, expect real assistant text instead of `[codex error] 401`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)