### PR TITLE
fix(codex): patch /configs/config.yaml model when MINIMAX_API_KEY present

### DIFF
--- a/codex_minimax_config.sh
+++ b/codex_minimax_config.sh
@@ -61,3 +61,32 @@ if command -v stat >/dev/null 2>&1; then
 fi
 
 echo "[codex-minimax] wrote ${CONFIG_TOML} model=${MODEL} provider=minimax"
+
+# Also patch /configs/config.yaml so molecule-runtime's load_config()
+# passes ${MODEL} to executor.py instead of the library default
+# (anthropic:claude-opus-4-7), which codex CLI rejects with
+# `unknown model 'anthropic:claude-opus-4-7' (2013)` and hangs the
+# first turn until task_complete that never arrives. Caught live on
+# the 4-runtime A2A E2E (2026-05-03): codex executor took the turn
+# lock, called turn/start with the wrong model, and never released
+# — every subsequent A2A request piled up in the workspace-server
+# queue as "busy".
+#
+# The provisioner has a MODEL_PROVIDER pass-through (ec2.go:1923) but
+# never exports it from user-data, so the only path for a runtime to
+# get the right model is to patch config.yaml from the install-time
+# context that knows about MINIMAX_API_KEY.
+WORKSPACE_CONFIG_DIR="${WORKSPACE_CONFIG_PATH:-/configs}"
+WORKSPACE_CONFIG="${WORKSPACE_CONFIG_DIR}/config.yaml"
+if [ -f "$WORKSPACE_CONFIG" ] && [ -w "$WORKSPACE_CONFIG_DIR" ]; then
+  if grep -qE '^model:' "$WORKSPACE_CONFIG"; then
+    sed -i.bak "s|^model: .*|model: '${MODEL}'|" "$WORKSPACE_CONFIG" && rm -f "${WORKSPACE_CONFIG}.bak"
+  else
+    printf "model: '%s'\n" "$MODEL" >> "$WORKSPACE_CONFIG"
+  fi
+  echo "[codex-minimax] patched ${WORKSPACE_CONFIG} model=${MODEL}"
+elif [ -f "$WORKSPACE_CONFIG" ]; then
+  # Read-only mount or wrong owner — log so operators can debug
+  # rather than silently shipping the wrong default model.
+  echo "[codex-minimax] WARN: ${WORKSPACE_CONFIG} exists but ${WORKSPACE_CONFIG_DIR} not writable; runtime will use default model" >&2
+fi

--- a/tests/test_codex_minimax_config.sh
+++ b/tests/test_codex_minimax_config.sh
@@ -80,6 +80,45 @@ env MINIMAX_API_KEY="mm-test-123" CODEX_MINIMAX_MODEL="MiniMax-M2.1" \
 assert "case3 picks up model override" \
   "grep -q 'model = .MiniMax-M2.1.' '$WORK/codex/config.toml'"
 
+# ---- case 5: WORKSPACE_CONFIG_PATH (config.yaml model patch) -------
+echo "=== case 5: patches /configs/config.yaml model field ==="
+rm -rf "$WORK/codex" "$WORK/configs"
+mkdir -p "$WORK/codex" "$WORK/configs"
+cat > "$WORK/configs/config.yaml" <<EOF
+name: test-ws
+runtime: codex
+a2a:
+  port: 8000
+  streaming: true
+EOF
+env MINIMAX_API_KEY="mm-test-123" HOME="$WORK" CODEX_HOME="$WORK/codex" \
+    WORKSPACE_CONFIG_PATH="$WORK/configs" PATH="/usr/bin:/bin" \
+  bash "$SCRIPT" > "$WORK/case5.out" 2>&1 || true
+
+assert "case5 logs config.yaml patch" "grep -q 'patched .*config.yaml' '$WORK/case5.out'"
+assert "case5 appends model to config.yaml" \
+  "grep -q \"model: 'codex-MiniMax-M2.7'\" '$WORK/configs/config.yaml'"
+
+# ---- case 6: existing model in config.yaml gets replaced -----------
+echo "=== case 6: replaces existing model line in config.yaml ==="
+rm -rf "$WORK/codex"
+mkdir -p "$WORK/codex"
+cat > "$WORK/configs/config.yaml" <<EOF
+name: test-ws
+model: anthropic:claude-opus-4-7
+runtime: codex
+EOF
+env MINIMAX_API_KEY="mm-test-123" HOME="$WORK" CODEX_HOME="$WORK/codex" \
+    WORKSPACE_CONFIG_PATH="$WORK/configs" PATH="/usr/bin:/bin" \
+  bash "$SCRIPT" > "$WORK/case6.out" 2>&1 || true
+
+assert "case6 model replaced (no anthropic line)" \
+  "! grep -q 'anthropic:claude-opus-4-7' '$WORK/configs/config.yaml'"
+assert "case6 model set to codex-MiniMax-M2.7" \
+  "grep -q \"model: 'codex-MiniMax-M2.7'\" '$WORK/configs/config.yaml'"
+assert "case6 has exactly one model: line" \
+  "[ \"\$(grep -cE '^model:' '$WORK/configs/config.yaml')\" = '1' ]"
+
 # ---- case 4: MINIMAX_API_BASE override (China region) --------------
 echo "=== case 4: base_url override (China region) ==="
 rm -rf "$WORK/codex"


### PR DESCRIPTION
## Summary

- `codex_minimax_config.sh` now also writes `model: '<MINIMAX_MODEL>'` into `/configs/config.yaml` (via `WORKSPACE_CONFIG_PATH`), not just `~/.codex/config.toml`.
- Two new tests (case 5: append; case 6: replace existing wrong model). All 18 assertions pass.

## Why

`molecule-runtime`'s `load_config()` returns the library default `anthropic:claude-opus-4-7` when `/configs/config.yaml` has no `model:` field. The codex executor then passes that to `turn/start` and codex CLI rejects with `unknown model 'anthropic:claude-opus-4-7' (2013)`. The executor holds the turn lock waiting for a `task_complete` that never comes, and every subsequent A2A request piles up as `busy` in the workspace-server queue.

The provisioner has a `MODEL_PROVIDER → config.yaml` pass-through (`ec2.go:1923`) but `MODEL_PROVIDER` is never exported in user-data — so the only path for a template to override the default is to patch `config.yaml` from the install-time context that knows about `MINIMAX_API_KEY`.

Caught live on the 4-runtime A2A E2E (2026-05-03), where a fresh codex+MiniMax workspace returned `[codex error] unexpected status 400 Bad Request: invalid params, unknown model 'anthropic:claude-opus-4-7'` until I ssh'd in and patched `/configs/config.yaml` by hand. After the patch, A2A returned `pong` immediately.

## Test plan

- [x] `bash tests/test_codex_minimax_config.sh` → 18/18 pass
- [ ] Verify on a fresh codex+MiniMax SaaS provision: A2A returns text on first try (no manual config edit needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)