### PR TITLE
feat(executor): codex turn/steer for true mid-turn push parity with claude-code

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -135,6 +135,66 @@ class CodexAppServerExecutor(AgentExecutor):
             )
             return
 
+        # Push parity with claude-code: when a new message arrives while
+        # a turn is already in flight, inject it into the active turn
+        # via codex's `turn/steer` RPC instead of blocking on the lock
+        # for ~minutes until the prior turn finishes. This is the
+        # documented v2 codex app-server protocol primitive — see
+        # codex-rs/app-server/README.md§Steer-an-active-turn — and
+        # gives codex true mid-turn push semantics matching the
+        # `notifications/claude/channel` path Claude Code uses.
+        #
+        # The agent then sees the new prompt as additional input in the
+        # active turn's context. Per the molecule MCP server's
+        # instructions string, the agent replies via send_message_to_user
+        # (canvas) or delegate_task (peer) — the platform's reply path
+        # is tool-based, not the A2A response shape — so this execute()
+        # returning a placeholder is correct: the actual reply lands
+        # via the tool-call route, not through this event_queue.
+        if (
+            self._turn_lock.locked()
+            and self._app_server is not None
+            and self._thread_id is not None
+            and self._current_turn_id is not None
+        ):
+            try:
+                await self._app_server.request(
+                    "turn/steer",
+                    {
+                        "threadId": self._thread_id,
+                        "input": [{"type": "text", "text": prompt}],
+                        "expectedTurnId": self._current_turn_id,
+                    },
+                    timeout=5.0,
+                )
+                logger.info(
+                    "codex push: steered into active turn %s",
+                    self._current_turn_id,
+                )
+                # Status placeholder for the A2A response. The peer or
+                # canvas wrapper sees this; the agent's substantive
+                # reply comes via send_message_to_user / delegate_task
+                # MCP tool calls within the steered turn's response.
+                await event_queue.enqueue_event(
+                    new_text_message(
+                        "[steered into in-flight turn — agent will reply "
+                        "via send_message_to_user / delegate_task]"
+                    )
+                )
+                return
+            except (AppServerError, asyncio.TimeoutError) as exc:
+                # Steer failed — common causes:
+                #   - ActiveTurnNotSteerable (review/manual-compact turn)
+                #   - expectedTurnId mismatch (turn ended between our
+                #     locked-check and the steer request)
+                #   - app-server transport hiccup
+                # Fall through to the lock-and-wait path so the message
+                # still gets processed, just as a queued new turn.
+                logger.debug(
+                    "codex turn/steer failed (%s) — falling through to new-turn path",
+                    exc,
+                )
+
         async with self._turn_lock:
             try:
                 text = await self._run_turn(prompt)

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -47,6 +47,7 @@ class FakeAppServer:
         self.thread_start_response: dict | None = None
         self.turn_start_responses: list[dict] = []
         self.turn_start_raises: Exception | None = None
+        self.turn_steer_raises: Exception | None = None
 
     async def initialize(self, *, client_info: dict) -> dict:
         return {"userAgent": "fake/0.0"}
@@ -70,6 +71,10 @@ class FakeAppServer:
             return {"turn": {"id": f"tu_{self._next_turn}"}}
         if method == "turn/interrupt":
             return {}
+        if method == "turn/steer":
+            if self.turn_steer_raises:
+                raise self.turn_steer_raises
+            return {"turnId": (params or {}).get("expectedTurnId", "")}
         raise AssertionError(f"unexpected method: {method}")
 
     def subscribe(self, callback) -> "asyncio.coroutines.Coroutine":

--- a/tests/test_executor_paths.py
+++ b/tests/test_executor_paths.py
@@ -387,3 +387,118 @@ async def test_turn_start_accepts_legacy_turnId_field():
     text = await ex._run_turn("legacy")
     await driver_task
     assert text == ""  # no deltas pushed
+
+
+# ---- turn/steer push parity (mid-turn steering) ----------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_steers_when_turn_in_flight():
+    """When a NEW message arrives while a turn is already in flight,
+    execute() should fire `turn/steer` to inject the new prompt into
+    the active turn instead of blocking on _turn_lock for the full
+    prior-turn duration. Push parity with claude-code's
+    `notifications/claude/channel` mid-session interrupt.
+    """
+    fake = FakeAppServer()
+    ex = _make(fake)
+    queue = _CapturingQueue()
+
+    # Simulate "turn in flight": lock held + thread/turn ids set, as
+    # they would be from a real concurrent _run_turn() invocation.
+    ex._thread_id = "th_active"
+    ex._current_turn_id = "tu_active"
+    await ex._turn_lock.acquire()
+    try:
+        await ex.execute(_ctx("steered prompt"), queue)
+
+        # turn/steer should be the only routed call (no turn/start).
+        steer_calls = [
+            (m, p) for m, p in fake.requests if m == "turn/steer"
+        ]
+        start_calls = [m for m, _ in fake.requests if m == "turn/start"]
+        assert len(steer_calls) == 1, (
+            f"expected exactly one turn/steer, got {fake.requests}"
+        )
+        assert not start_calls, (
+            f"steer path must NOT also start a new turn, got {start_calls}"
+        )
+
+        method, params = steer_calls[0]
+        assert params["threadId"] == "th_active"
+        assert params["expectedTurnId"] == "tu_active"
+        assert params["input"] == [
+            {"type": "text", "text": "steered prompt"}
+        ]
+
+        # Placeholder delivered for the A2A response.
+        assert len(queue.events) == 1
+        assert "steered into in-flight turn" in repr(queue.events[0])
+    finally:
+        ex._turn_lock.release()
+
+
+@pytest.mark.asyncio
+async def test_execute_falls_through_when_no_active_turn():
+    """Lock not held / no turn id → original path (turn/start). The
+    steer branch is gated on (lock held AND turn id set) — partial
+    state should fall through to the new-turn path so we don't fire
+    a turn/steer against a non-existent turn id."""
+    fake = FakeAppServer()
+    ex = _make(fake)
+    queue = _CapturingQueue()
+
+    async def driver():
+        for _ in range(50):
+            if any(m == "turn/start" for m, _ in fake.requests):
+                break
+            await asyncio.sleep(0.01)
+        fake.push_event("agent_message_delta", delta="ok")
+        fake.push_event("task_complete", task_id="tu_1", last_agent_message="")
+
+    await asyncio.gather(ex.execute(_ctx("hi"), queue), driver())
+
+    # Confirms the steer branch did NOT fire when no turn was in flight.
+    assert not any(m == "turn/steer" for m, _ in fake.requests)
+    assert any(m == "turn/start" for m, _ in fake.requests)
+
+
+@pytest.mark.asyncio
+async def test_execute_falls_through_when_steer_raises_not_steerable():
+    """`turn/steer` returns ActiveTurnNotSteerable for review/manual-
+    compact turns OR if expectedTurnId mismatches (turn ended between
+    our lock-check and the steer call). On either, fall through to
+    the lock-and-wait path so the message still gets processed.
+    """
+    fake = FakeAppServer()
+    fake.turn_steer_raises = AppServerError("ActiveTurnNotSteerable")
+    ex = _make(fake)
+    queue = _CapturingQueue()
+
+    # Simulate active-turn state, but steer will raise.
+    ex._thread_id = "th_active"
+    ex._current_turn_id = "tu_active"
+    await ex._turn_lock.acquire()
+    # Release shortly so the fall-through path can acquire and proceed.
+    async def releaser():
+        await asyncio.sleep(0.05)
+        ex._turn_lock.release()
+    asyncio.create_task(releaser())
+
+    async def driver():
+        for _ in range(100):
+            if any(m == "turn/start" for m, _ in fake.requests):
+                break
+            await asyncio.sleep(0.01)
+        fake.push_event("agent_message_delta", delta="real reply")
+        fake.push_event("task_complete", task_id="tu_2", last_agent_message="")
+
+    await asyncio.gather(ex.execute(_ctx("retry"), queue), driver())
+
+    # Steer was attempted and failed; turn/start fired as fall-through.
+    assert any(m == "turn/steer" for m, _ in fake.requests)
+    assert any(m == "turn/start" for m, _ in fake.requests)
+    # The fall-through path delivered the real reply, not the placeholder.
+    text = repr(queue.events[-1])
+    assert "real reply" in text
+    assert "steered into in-flight" not in text


### PR DESCRIPTION
## What this fixes

Codex template's executor pre-PR serializes every A2A message via `_turn_lock` — a peer sending three messages in quick succession sees them processed serially, each ~minutes long. The agent never sees a new mid-flight message until the prior turn finishes. **No push semantic between turns.**

## The codex-side primitive that fixes it

OpenAI's codex CLI ships [`turn/steer`](https://github.com/openai/codex/blob/main/codex-rs/app-server/README.md#example-steer-an-active-turn) in its v2 app-server protocol:

> add user input to an already in-flight regular turn without starting a new turn; returns the active `turnId` that accepted the input.

Schema:
```typescript
TurnSteerParams = {
  threadId: string,
  input: Array<UserInput>,
  expectedTurnId: string,    // required precondition
}
```

This is the exact "interrupt my running turn with new user input" primitive equivalent to Claude Code's `notifications/claude/channel` push.

## Why we have to drive it from the adapter

Codex's MCP client doesn't forward arbitrary `notifications/*` from configured MCP servers — verified by reading `codex-rs/codex-mcp/src/connection_manager.rs` (no notification routing). So the molecule_runtime's `notifications/claude/channel` emissions never reach codex. `turn/steer` from the adapter side is the right primitive.

## How push reaches the agent

Adapter detects "lock held + active turn id set" in execute() → fires `turn/steer` → codex injects the new prompt into the active turn's context. Per the molecule MCP server's instructions, the agent replies via `send_message_to_user` / `delegate_task` tool calls — same tool-based reply path Claude Code uses post-notification.

The A2A response from the steered execute() is a short placeholder (`[steered into in-flight turn ...]`) — the actual reply lands via the tool-call route.

## Fall-through paths

| Steer failure | Cause | Adapter behavior |
|---|---|---|
| `ActiveTurnNotSteerable` | Review or manual-compact turn rejects steer | Fall through to lock-and-wait (original path) |
| `expectedTurnId` mismatch | Turn ended between our lock-check and the steer request (race window) | Fall through |
| App-server transport hiccup | Pipe/timeout | Fall through |

## Test plan

- [x] 3 new unit tests in `test_executor_paths.py` exact-shape-assert turn/steer params, no-active-turn fall-through, and steer-failure fall-through
- [x] Mutation-tested: gating the steer block on `if False:` makes both positive tests fail (proves the steer block is what discriminates)
- [x] All 28 executor tests pass (was 25)
- [ ] Post-merge: verify on a staging codex workspace by sending two A2A messages within 5s of each other and confirming the second one's prompt appears mid-first-turn in codex's response context

🤖 Generated with [Claude Code](https://claude.com/claude-code)