### PR TITLE
perf(Dockerfile): reorder layers so codex npm install caches across .py edits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,29 @@
 # Last resolved: 2026-05-03 (RFC #388 PR-2b).
 FROM python:3.11-slim@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
+# ─────────────────────────────────────────────────────────────────────
+# CACHE-FRIENDLY LAYER ORDER — read before adding new layers.
+#
+# Layers are ordered slowest-and-most-stable → fastest-and-most-changing.
+# When `cache-from: type=gha` hits, Docker reuses the cached output of a
+# layer iff (a) its command text is identical AND (b) every prior layer
+# was also a cache hit. Any earlier layer that changes invalidates ALL
+# subsequent layers.
+#
+# The expensive layers are:
+#   1. apt-get install (system deps)
+#   2. NodeSource setup_20.x + apt install nodejs (~80 MB)
+#   3. pip install -r requirements.txt
+#   4. npm install -g @openai/codex@^0.57 (codex CLI binary + deps)
+#
+# These ~rarely change (only on Dockerfile edits / requirements bumps /
+# codex pin bumps) so they belong UP TOP. The cheap, high-churn `COPY
+# *.py` layers belong AT THE BOTTOM. Putting the codex install below
+# the COPYs caused every adapter.py / executor.py / start.sh change to
+# bust its cache. Don't move the COPYs back above the codex install.
+# Same pattern shipped to template-hermes in PR #48.
+# ─────────────────────────────────────────────────────────────────────
+
 # System deps:
 #   curl, ca-certificates — TLS + Node tarball download
 #   git           — codex's agent tools use git
@@ -51,17 +74,14 @@ RUN pip install --no-cache-dir -r requirements.txt && \
       pip install --no-cache-dir --upgrade "molecule-ai-workspace-runtime==${RUNTIME_VERSION}"; \
     fi
 
-COPY adapter.py executor.py app_server.py __init__.py ./
-COPY start.sh /usr/local/bin/start.sh
-COPY codex_minimax_config.sh /usr/local/bin/codex_minimax_config.sh
-COPY codex_mcp_config.sh /usr/local/bin/codex_mcp_config.sh
-RUN chmod +x /usr/local/bin/start.sh \
-              /usr/local/bin/codex_minimax_config.sh \
-              /usr/local/bin/codex_mcp_config.sh
-
 # --- Install the OpenAI Codex CLI globally as root (binary lives in
 # /usr/lib/node_modules and symlinks into /usr/bin/codex; available to
 # both root and the agent user).
+#
+# This MUST stay above the COPY *.py layers below (see cache-order
+# rationale at the top). The npm install command text is fixed — the
+# pin (^0.57) is what changes the cache key, so a deliberate bump
+# invalidates this layer; routine Python edits do not.
 #
 # Pin to ^0.57 — MiniMax's official codex-cli docs flag a compat issue
 # on later versions ("The latest version of Codex CLI has compatibility
@@ -70,6 +90,25 @@ RUN chmod +x /usr/local/bin/start.sh \
 # re-testing the executor against the new release's notification schema.
 RUN npm install -g @openai/codex@^0.57
 
+# ─────────────────────────────────────────────────────────────────────
+# Fast-changing layers — keep at the bottom.
+# Edits to *.py / start.sh / codex_*_config.sh only invalidate from here
+# down (~5-10 s of work) instead of busting the codex npm install.
+# ─────────────────────────────────────────────────────────────────────
+COPY adapter.py executor.py app_server.py __init__.py ./
+COPY start.sh /usr/local/bin/start.sh
+COPY codex_minimax_config.sh /usr/local/bin/codex_minimax_config.sh
+COPY codex_mcp_config.sh /usr/local/bin/codex_mcp_config.sh
+RUN chmod +x /usr/local/bin/start.sh \
+              /usr/local/bin/codex_minimax_config.sh \
+              /usr/local/bin/codex_mcp_config.sh
+
+# Preserved from pre-reorder Dockerfile — these 4 lines flip USER/WORKDIR
+# with no operation between them, so they're functionally a no-op (final
+# state matches what was already in effect). Likely leftover from an
+# earlier refactor where agent-user operations lived here. Kept rather
+# than deleted so this PR stays scoped to the cache-order reorder; if
+# the reviewer confirms they're dead, they can come out in a follow-up.
 USER agent
 WORKDIR /home/agent
 USER root


### PR DESCRIPTION
## Summary

- Moves \`RUN npm install -g @openai/codex@^0.57\` ABOVE the \`COPY adapter.py / executor.py / app_server.py / __init__.py / start.sh / codex_*_config.sh\` block.
- Adds a 24-line cache-order rationale comment at the top of the Dockerfile.

## Why

Same anti-pattern + same fix as [Molecule-AI/molecule-ai-workspace-template-hermes#48](https://github.com/Molecule-AI/molecule-ai-workspace-template-hermes/pull/48) (already merged). Today, every Python file edit invalidates the codex npm install (~120 MB of node_modules), forcing it to re-run on every push. After the reorder, only requirements.txt / Dockerfile-prefix changes invalidate that layer.

A scope check across the four template repos:
- ✅ template-hermes: had the anti-pattern, fixed in PR #48 (merged)
- ✅ template-codex: had the anti-pattern (this PR)
- ✅ template-claude-code: already cache-friendly (npm install on line 18, BEFORE the COPYs)
- ✅ template-openclaw: already cache-friendly (npm install on line 16, BEFORE the COPYs)

So this PR completes the consistency pass.

## Local verification

- Cold build: clean, 441 MB image
- Smoke tests:
  - \`codex --version\` → \`codex-cli 0.57.0\`
  - \`import adapter, executor, app_server\` cleanly from /app
  - All three \`/usr/local/bin/\` scripts present, root-owned, +x
- **Incremental build (touch adapter.py): 0s** — full cache hit on the codex install layer

## Reviewer note: dead-code observation (NOT in this PR)

The original Dockerfile contains a 4-line block right after the codex install:

\`\`\`dockerfile
USER agent
WORKDIR /home/agent
USER root
WORKDIR /app
\`\`\`

There's no operation between the directives — likely leftover from an earlier refactor where agent-user operations lived here. **Preserved in this PR** (with a code-comment flagging it) to keep the scope tight to the cache reorder. Reviewer's call whether to drop it in a follow-up.

## Expected impact in CI

The first publish-image run on main after merge is a cold build (no benefit). All subsequent runs that touch only .py / .sh files (the common edit shape) will hit the cached codex install and complete in ~1 min instead of 2-3 min. Modest gain per run; consistency benefit across all 4 templates.

## Test plan

- [ ] CI publish-image on this PR succeeds (validates the new layer order against GHA-cache-from)
- [ ] After merge, observe the next 2-3 publish-image runs on main — expect <1.5 min once the new cache layer is seeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)